### PR TITLE
Add FastAPI MCP server scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.env
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,110 @@
-# MCP_Server_forWeb
-202509_MCPServerForeWebQueries
+# MCP Server for eWeb Integrations
+
+This project provides a minimal FastAPI-based MCP (Model Context Protocol) server
+that translates natural-language retail operations requests into eWeb API
+calls. It wraps the supplier stock and sales history endpoints, enabling ChatGPT
+and other MCP-compatible clients to surface inventory and sales insights.
+
+## Project Layout
+
+```
+.
+├── requirements.txt      # Python dependencies
+└── src/
+    ├── __init__.py
+    ├── eweb_client.py    # HTTP wrapper around the eWeb API
+    └── mcp_server.py     # FastAPI application exposing MCP endpoints
+```
+
+## Prerequisites
+
+* Python 3.10+
+* pip (or another PEP 517 compatible installer)
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Credentials and connection details are loaded from environment variables. You
+can set them directly in your shell or create a `.env` file in the project root.
+
+Required variables:
+
+* `EWEB_BASE_URL` – Base URL for the eWeb instance (e.g., `https://example.com/api`).
+* `EWEB_API_KEY` – API key or bearer token.
+
+Optional variables:
+
+* `EWEB_ACCOUNT_ID` – Account header required by some deployments.
+* `EWEB_DEFAULT_SUPPLIER_ID` – Default supplier identifier used for stock queries.
+
+Example `.env` file:
+
+```
+EWEB_BASE_URL=https://example.com/api
+EWEB_API_KEY=replace-me
+EWEB_ACCOUNT_ID=demo-account
+EWEB_DEFAULT_SUPPLIER_ID=12345
+```
+
+## Running the Server
+
+Activate your virtual environment (if applicable) and start the FastAPI
+application with Uvicorn:
+
+```bash
+uvicorn src.mcp_server:app --reload --port 8000
+```
+
+The server exposes a health endpoint at `GET /healthz` and an intent processing
+endpoint at `POST /intent`.
+
+## Example Request Flow
+
+1. **ChatGPT (or another MCP client) request**
+
+   Natural language prompt: “Citizen Watches six-month sales.”
+
+2. **Server interpretation**
+
+   The `/intent` endpoint converts the request into a sales history query. You
+   can test locally with curl:
+
+   ```bash
+   curl -X POST http://localhost:8000/intent \
+        -H "Content-Type: application/json" \
+        -d '{"query": "Citizen Watches six-month sales"}'
+   ```
+
+3. **Sample response**
+
+   ```json
+   {
+     "intent": "sales_history",
+     "parameters": {
+       "start_date": "2024-03-17",
+       "end_date": "2024-09-13",
+       "brand": "Citizen"
+     },
+     "data": {
+       "...": "JSON payload returned from the eWeb /sales/history endpoint"
+     }
+   }
+   ```
+
+Swap the prompt to "Citizen inventory status" (or supply a different supplier ID
+and brand) to receive stock details via the `supplier_stock` action.
+
+## Development Notes
+
+* The eWeb client currently supports supplier stock and sales history endpoints.
+  Additional endpoints can be added following the same pattern in
+  `src/eweb_client.py`.
+* Authentication headers assume bearer token usage. Adjust the `_headers`
+  implementation if your deployment requires another scheme.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0
+httpx>=0.27.0
+requests>=2.31.0
+pydantic>=2.6.0
+python-dotenv>=1.0.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialization for the MCP server project."""

--- a/src/eweb_client.py
+++ b/src/eweb_client.py
@@ -1,0 +1,189 @@
+"""Client wrapper for interacting with the eWeb API.
+
+The client is intentionally lightweight and focuses on the endpoints needed
+for inventory and sales related MCP interactions. Credentials and connection
+settings are loaded from environment variables and ``.env`` files via
+:mod:`python-dotenv`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+import os
+
+import httpx
+from dotenv import load_dotenv
+
+
+@dataclass
+class EWebCredentials:
+    """Holds the credentials required for the eWeb API."""
+
+    base_url: str
+    api_key: str
+    account_id: Optional[str] = None
+    default_supplier_id: Optional[str] = None
+
+
+class EWebClient:
+    """HTTP client for the eWeb API.
+
+    Parameters
+    ----------
+    base_url:
+        Base URL for the eWeb instance. Defaults to the value from the
+        ``EWEB_BASE_URL`` environment variable.
+    api_key:
+        API key or token used for authenticating with the eWeb API. Defaults to
+        ``EWEB_API_KEY``.
+    account_id:
+        Optional account identifier used by some eWeb installations. Loaded
+        from ``EWEB_ACCOUNT_ID`` when not provided.
+    default_supplier_id:
+        Optional default supplier identifier for inventory queries. Loaded from
+        ``EWEB_DEFAULT_SUPPLIER_ID`` when not provided.
+    timeout:
+        Request timeout in seconds. Defaults to 30 seconds.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        account_id: Optional[str] = None,
+        default_supplier_id: Optional[str] = None,
+        timeout: float = 30.0,
+    ) -> None:
+        load_dotenv()
+
+        base_url = base_url or os.getenv("EWEB_BASE_URL")
+        api_key = api_key or os.getenv("EWEB_API_KEY")
+        account_id = account_id or os.getenv("EWEB_ACCOUNT_ID")
+        default_supplier_id = default_supplier_id or os.getenv(
+            "EWEB_DEFAULT_SUPPLIER_ID"
+        )
+
+        if not base_url:
+            raise ValueError("EWEB_BASE_URL must be provided via environment variables")
+        if not api_key:
+            raise ValueError("EWEB_API_KEY must be provided via environment variables")
+
+        self.credentials = EWebCredentials(
+            base_url=base_url.rstrip("/"),
+            api_key=api_key,
+            account_id=account_id,
+            default_supplier_id=default_supplier_id,
+        )
+        self.timeout = timeout
+
+    # ------------------------------------------------------------------
+    # Low-level helpers
+    # ------------------------------------------------------------------
+    def _headers(self) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self.credentials.api_key}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        if self.credentials.account_id:
+            headers["X-Account-ID"] = self.credentials.account_id
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.credentials.base_url}/{path.lstrip('/')}"
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.request(
+                method=method,
+                url=url,
+                headers=self._headers(),
+                params={k: v for k, v in (params or {}).items() if v is not None},
+                json=json,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    # ------------------------------------------------------------------
+    # Public API methods
+    # ------------------------------------------------------------------
+    def get_supplier_stock(
+        self,
+        *,
+        supplier_id: Optional[str] = None,
+        brand: Optional[str] = None,
+        page: int = 1,
+        page_size: int = 100,
+    ) -> Dict[str, Any]:
+        """Retrieve stock details for a supplier.
+
+        Parameters
+        ----------
+        supplier_id:
+            Identifier for the supplier whose inventory should be returned.
+            Defaults to ``EWEB_DEFAULT_SUPPLIER_ID`` if configured.
+        brand:
+            Optional brand filter.
+        page, page_size:
+            Pagination controls passed to the API.
+        """
+
+        supplier_id = supplier_id or self.credentials.default_supplier_id
+        if not supplier_id:
+            raise ValueError(
+                "A supplier_id is required. Configure EWEB_DEFAULT_SUPPLIER_ID or pass a value."
+            )
+
+        params = {
+            "supplierId": supplier_id,
+            "brand": brand,
+            "page": page,
+            "pageSize": page_size,
+        }
+        return self._request("GET", "/inventory/supplier-stock", params=params)
+
+    def get_sales_history(
+        self,
+        *,
+        sku: Optional[str] = None,
+        upc: Optional[str] = None,
+        brand: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        location_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Retrieve sales history for a SKU or brand.
+
+        Parameters
+        ----------
+        sku, upc:
+            Identifiers for the item whose sales history should be retrieved.
+        brand:
+            Optional brand-level aggregation supported by some eWeb setups.
+        start_date, end_date:
+            ISO-8601 formatted dates bounding the sales window.
+        location_id:
+            Optional location or store identifier when supported.
+        """
+
+        if not any([sku, upc, brand]):
+            raise ValueError("At least one of sku, upc, or brand must be provided")
+
+        params = {
+            "sku": sku,
+            "upc": upc,
+            "brand": brand,
+            "startDate": start_date,
+            "endDate": end_date,
+            "locationId": location_id,
+        }
+        return self._request("GET", "/sales/history", params=params)
+
+
+__all__ = ["EWebClient", "EWebCredentials"]

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1,0 +1,123 @@
+"""FastAPI application exposing MCP-compatible endpoints."""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .eweb_client import EWebClient
+
+load_dotenv()
+
+app = FastAPI(title="eWeb MCP Server", version="0.1.0")
+
+
+class IntentRequest(BaseModel):
+    """Schema representing an intent expressed in natural language."""
+
+    query: str = Field(..., description="Natural language request from the user")
+    supplier_id: Optional[str] = Field(
+        default=None, description="Optional supplier identifier override"
+    )
+
+
+class IntentResponse(BaseModel):
+    """Structured response returned by the MCP server."""
+
+    intent: str
+    parameters: Dict[str, Any]
+    data: Dict[str, Any]
+
+
+def _extract_brand(text: str) -> Optional[str]:
+    candidates = re.findall(r"\b([A-Z][A-Za-z0-9&'-]+)\b", text)
+    for candidate in candidates:
+        if candidate.lower() in {"show", "get", "sales", "inventory", "stock"}:
+            continue
+        return candidate
+    return None
+
+
+def _extract_time_window(text: str) -> Dict[str, str]:
+    now = datetime.utcnow()
+    text = text.lower()
+    number_words = {
+        "one": 1,
+        "two": 2,
+        "three": 3,
+        "four": 4,
+        "five": 5,
+        "six": 6,
+        "seven": 7,
+        "eight": 8,
+        "nine": 9,
+        "ten": 10,
+        "eleven": 11,
+        "twelve": 12,
+    }
+
+    match = re.search(r"(\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)[-\s]*(day|week|month|year)s?", text)
+    if match:
+        quantity_raw, unit = match.groups()
+        quantity = int(quantity_raw) if quantity_raw.isdigit() else number_words.get(quantity_raw, 1)
+    elif "last year" in text:
+        quantity, unit = 1, "year"
+    elif "last month" in text:
+        quantity, unit = 1, "month"
+    elif "last week" in text:
+        quantity, unit = 1, "week"
+    else:
+        return {}
+
+    if unit.startswith("day"):
+        delta = timedelta(days=quantity)
+    elif unit.startswith("week"):
+        delta = timedelta(weeks=quantity)
+    elif unit.startswith("month"):
+        delta = timedelta(days=30 * quantity)
+    else:
+        delta = timedelta(days=365 * quantity)
+
+    start = now - delta
+    return {"start_date": start.strftime("%Y-%m-%d"), "end_date": now.strftime("%Y-%m-%d")}
+
+
+@app.post("/intent", response_model=IntentResponse)
+def handle_intent(payload: IntentRequest) -> IntentResponse:
+    query_lower = payload.query.lower()
+    client = EWebClient()
+
+    if any(word in query_lower for word in ["inventory", "stock"]):
+        supplier_id = payload.supplier_id or client.credentials.default_supplier_id
+        brand = _extract_brand(payload.query)
+        if not supplier_id:
+            raise HTTPException(
+                status_code=400,
+                detail="Supplier ID is required for inventory queries. Set EWEB_DEFAULT_SUPPLIER_ID or provide one in the request.",
+            )
+        params = {"supplier_id": supplier_id, "brand": brand}
+        data = client.get_supplier_stock(supplier_id=supplier_id, brand=brand)
+        return IntentResponse(intent="supplier_stock", parameters=params, data=data)
+
+    if "sale" in query_lower:
+        params = _extract_time_window(payload.query)
+        brand = _extract_brand(payload.query)
+        params.update({"brand": brand})
+        if not brand:
+            raise HTTPException(
+                status_code=400,
+                detail="Unable to determine a brand or item for the sales query. Please specify a brand name.",
+            )
+        data = client.get_sales_history(brand=brand, **params)
+        return IntentResponse(intent="sales_history", parameters=params, data=data)
+
+    raise HTTPException(status_code=400, detail="Unable to interpret the requested intent.")
+
+
+@app.get("/healthz")
+def health_check() -> Dict[str, str]:
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- scaffold a Python project with an eWeb API client wrapper
- expose MCP-compatible FastAPI endpoints for supplier stock and sales history intents
- document setup, configuration, and usage in the README

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68cf608a7b1883229d4dcbd8b1fa6511